### PR TITLE
Update README, mention dep on activerecord-postgres-hstore

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ TODO: Write a gem description
 
 Add this line to your application's Gemfile:
 
-    gem 'uuid_support'
+    gem 'activerecord-postgres-uuid'
 
 And then execute:
 
@@ -14,11 +14,32 @@ And then execute:
 
 Or install it yourself as:
 
-    $ gem install uuid_support
+    $ gem install activerecord-postgres-uuid
+
+### Note for Rails 3.1 and Above
+
+You'll also need to install `activerecord-postgres-hstore`:
+
+    gem "activerecord-postgres-hstore", git: "git://github.com/softa/activerecord-postgres-hstore.git"
+
+Referencing the master branch of `activerecord-postgres-hstore` should
+only be neccissary until it hits version `0.4.0`.
 
 ## Usage
 
-TODO: Write usage instructions here
+Once the gem is installed you can start safely referencing UUID column
+types in your migrations:
+
+    class CreatePayments < ActiveRecord::Migration
+      def change
+        create_table :payments do |t|
+          t.uuid :uuid
+          t.integer :amount
+
+          t.timestamps
+        end
+      end
+    end
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# UuidSupport
+# Activerecord Postgres UUID Support
 
-TODO: Write a gem description
+Adds support for PostgreSQL 128 bit UUID column type to ActiveRecord
 
 ## Installation
 

--- a/uuid_support.gemspec
+++ b/uuid_support.gemspec
@@ -1,6 +1,4 @@
 # -*- encoding: utf-8 -*-
-require File.expand_path('../lib/active_record/postgresql/uuid/version', __FILE__)
-
 Gem::Specification.new do |gem|
   gem.authors       = ["Ivan Vanderbyl"]
   gem.email         = ["ivanvanderbyl@me.com"]
@@ -13,7 +11,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   gem.name          = "activerecord-postgres-uuid"
   gem.require_paths = ["lib"]
-  gem.version       = ActiveRecord::PostgreSQL::UUIDColumn::VERSION
+  gem.version       = "0.0.1"
 
   gem.add_dependency "rails", ">= 3.1.0"
   gem.add_dependency "pg", ">= 0.12.0"

--- a/uuid_support.gemspec
+++ b/uuid_support.gemspec
@@ -15,6 +15,6 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = ActiveRecord::PostgreSQL::UUIDColumn::VERSION
 
-  gem.add_dependency "activerecord", ">= 3.1.0"
+  gem.add_dependency "rails", ">= 3.1.0"
   gem.add_dependency "pg", ">= 0.12.0"
 end


### PR DESCRIPTION
First off, thanks so much for this gem. I've been using a similar hack for quite a while and it's nice to see a more polished version in gem form.

That being said, I had trouble getting this working in a brand new Rails 3.2.3 app. Upon running migrations, I'd get the following error:

```
undefined local variable or method `native_database_types_without_hstore' for #<ActiveRecord::ConnectionAdapters::PostgreSQLAdapter:0x007f9164197e48>
```

After some digging, it seems you were referencing methods from the `activerecord-postgres-hstore` gem. After including that in my Gemfile everything was hunky dory.

This patch is just some updates to the README to help out anyone who runs into similar issues. I wasn't sure if `activerecord-postgres-hstore` was intended to be a dependency of your gem, so I left the gemspec alone.

That's it! Thanks for the great gem!
